### PR TITLE
Feature: add alternative to use signature in query params

### DIFF
--- a/php/sdk.php
+++ b/php/sdk.php
@@ -103,7 +103,8 @@ class SmccSdk {
      * @return bool
      */
     public function is_valid_request() {
-        return $this->signature($this->get_raw_body()) === @$_SERVER['HTTP_X_SMCCSDK_SIGNATURE'];
+        $signature = $this->signature($this->get_raw_body());
+        return $signature === @$_SERVER['HTTP_X_SMCCSDK_SIGNATURE'] || $signature === @$_REQUEST['SMCCSDK_SIGNATURE'];
     }
 
     /**


### PR DESCRIPTION
@elhu: As you ask, the SDK supports now the signature in query params if signature header is missing.
